### PR TITLE
System install docs PR

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -147,3 +147,14 @@ jobs:
         env:
           ALPHAGSM_RUN_INTEGRATION: "1"
         run: pytest ${{ matrix.test-file }}
+
+  system-install-test:
+    runs-on: ubuntu-latest
+    needs: unit-test
+    name: system-install-test
+    steps:
+      - name: Checkout AlphaGSM code
+        uses: actions/checkout@v4
+      - name: Run system-wide install test in container
+        run: |
+          bash ./system_install_tests/run_system_install_in_container.sh

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -282,6 +282,11 @@ Main template:
 
 - [alphagsm.conf-template](alphagsm.conf-template)
 
+Documented installation layouts:
+
+- [docs/install/local-user.md](docs/install/local-user.md)
+- [docs/install/system-wide.md](docs/install/system-wide.md)
+
 Important environment variables:
 
 - `ALPHAGSM_CONFIG_LOCATION`
@@ -290,6 +295,15 @@ Important environment variables:
 - `ALPHAGSM_DEBUG`
 
 The smoke tests rely on temporary config files and `ALPHAGSM_CONFIG_LOCATION` to isolate state per run.
+
+For system-wide installs, the intended layout is:
+
+- `/etc/alphagsm.conf`
+- `/home/alphagsm/`
+- `/usr/local/lib/alphagsm`
+- `/usr/local/sbin/gitalphagsm`
+- `/usr/local/bin/alphagsm`
+- `/etc/sudoers.d/gameservers`
 
 ## Documentation Contract
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -50,6 +50,8 @@ At runtime, the user-facing call path is:
   Pytest-driven end-to-end tests.
 - [smoke_tests](smoke_tests)
   Shell-driven streamed lifecycle runners used by CI and documentation.
+- [system_install_tests](system_install_tests)
+  Container-based validation of the system-wide install layout.
 - [docs](docs)
   User-facing documentation.
 
@@ -231,6 +233,20 @@ bash ./smoke_tests/run_minecraft_vanilla.sh
 bash ./smoke_tests/run_tf2.sh
 ```
 
+### System install tests
+
+Location:
+
+- [system_install_tests](system_install_tests)
+
+Command:
+
+```bash
+bash ./system_install_tests/run_system_install_in_container.sh
+```
+
+This validates the system-wide installer in a fresh Linux container and checks the expected `/etc`, `/usr/local`, `/home/alphagsm`, and sudoers layout.
+
 ## Linting
 
 Lint is driven by [lint.sh](lint.sh).
@@ -259,6 +275,7 @@ Current job layout:
 3. `unit-test`
 4. matrix `smoke-test`
 5. matrix `integration-test`
+6. `system-install-test`
 
 Triggers:
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ These scripts are useful because they show a full real flow:
 4. check it
 5. stop it cleanly
 
+There is also a container-based system install check in `system_install_tests/` that verifies the shared Linux install layout without touching the host machine.
+
 ## Step-By-Step Server Guides
 
 - [Documentation Index](docs/README.md)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Some server types need one extra thing:
 
 ## Fast Start
 
+If you want AlphaGSM to install itself for you, use one of these first:
+
+- local-user install: [docs/install/local-user.md](docs/install/local-user.md)
+- system-wide install: [docs/install/system-wide.md](docs/install/system-wide.md)
+
 ### 1. Install the Python packages
 
 ```bash
@@ -140,6 +145,8 @@ These scripts are useful because they show a full real flow:
 ## Step-By-Step Server Guides
 
 - [Documentation Index](docs/README.md)
+- [Local User Install](docs/install/local-user.md)
+- [System-Wide Install](docs/install/system-wide.md)
 - [Minecraft Vanilla Guide](docs/servers/minecraft-vanilla.md)
 - [Team Fortress 2 Guide](docs/servers/team-fortress-2.md)
 - [CS:GO Guide](docs/servers/counter-strike-global-offensive.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ If you are not sure where to start, pick your server below and follow that guide
 
 ## Server Guides
 
+- [Local User Install](install/local-user.md)
+- [System-Wide Install](install/system-wide.md)
 - [Minecraft Vanilla](servers/minecraft-vanilla.md)
 - [Team Fortress 2](servers/team-fortress-2.md)
 - [Counter-Strike: Global Offensive](servers/counter-strike-global-offensive.md)

--- a/docs/install/local-user.md
+++ b/docs/install/local-user.md
@@ -1,0 +1,39 @@
+# Local User Install
+
+This install path is for one Linux user running AlphaGSM for their own account.
+
+## What It Does
+
+The local install script:
+
+- copies AlphaGSM into your home directory
+- makes a config file for you
+- creates a command link in `~/.local/bin`
+
+## Run It
+
+From the repository root:
+
+```bash
+bash ./scripts/install-local-user.sh
+```
+
+## Default Paths
+
+- code: `~/.local/lib/alphagsm`
+- command: `~/.local/bin/alphagsm`
+- config: `~/.local/lib/alphagsm/alphagsm.conf`
+
+## After Install
+
+If `~/.local/bin` is not already in your `PATH`, add it in your shell profile:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Then you can run:
+
+```bash
+alphagsm --help
+```

--- a/docs/install/system-wide.md
+++ b/docs/install/system-wide.md
@@ -1,0 +1,47 @@
+# System-Wide Install
+
+This install path is for a shared machine where AlphaGSM is installed once and used by multiple people.
+
+## Layout
+
+The system-wide install is designed around these paths:
+
+- overall config: `/etc/alphagsm.conf`
+- shared download user home: `/home/alphagsm`
+- code: `/usr/local/lib/alphagsm`
+- shared command: `/usr/local/bin/alphagsm`
+- root git helper: `/usr/local/sbin/gitalphagsm`
+- sudoers file: `/etc/sudoers.d/gameservers`
+
+The shared download user can own common download data so that normal users are not all downloading and storing the same artifacts at the same time.
+
+## Run It
+
+Run as root:
+
+```bash
+sudo bash ./scripts/install-system-wide.sh
+```
+
+## Shared Download User
+
+The installer creates or uses the `alphagsm` system user and prepares:
+
+- `/home/alphagsm/gitlive`
+- `/home/alphagsm/downloads`
+
+## Sudoers Entry
+
+The installer writes:
+
+```text
+%alphagsm       ALL = (alphagsm) NOPASSWD:/usr/local/lib/alphagsm/alphagsm-downloads
+```
+
+That allows the right group to run the shared downloader helper as the `alphagsm` user without a password prompt.
+
+## Notes
+
+- This is the better fit for a shared host.
+- The root helper `gitalphagsm` is installed to `/usr/local/sbin/gitalphagsm`.
+- The `alphagsm` command is exposed through `/usr/local/bin/alphagsm`.

--- a/scripts/gitalphagsm
+++ b/scripts/gitalphagsm
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTALL_ROOT="${INSTALL_ROOT:-/usr/local/lib/alphagsm}"
+
+if [[ ! -d "$INSTALL_ROOT/.git" ]]; then
+  echo "No git repository found at $INSTALL_ROOT" >&2
+  exit 1
+fi
+
+git -C "$INSTALL_ROOT" "$@"

--- a/scripts/install-local-user.sh
+++ b/scripts/install-local-user.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_ROOT="${INSTALL_ROOT:-$HOME/.local/lib/alphagsm}"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+CONFIG_PATH="$INSTALL_ROOT/alphagsm.conf"
+
+mkdir -p "$INSTALL_ROOT" "$BIN_DIR"
+
+cp -a "$REPO_ROOT"/. "$INSTALL_ROOT"/
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  cp "$INSTALL_ROOT/alphagsm.conf-template" "$CONFIG_PATH"
+fi
+
+ln -sfn "$INSTALL_ROOT/alphagsm" "$BIN_DIR/alphagsm"
+
+cat <<EOF
+AlphaGSM local install complete.
+
+Install root:
+  $INSTALL_ROOT
+
+Command link:
+  $BIN_DIR/alphagsm
+
+Config file:
+  $CONFIG_PATH
+
+If '$BIN_DIR' is not in your PATH, add this to your shell profile:
+  export PATH="$BIN_DIR:\$PATH"
+EOF

--- a/scripts/install-system-wide.sh
+++ b/scripts/install-system-wide.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_ROOT="${INSTALL_ROOT:-/usr/local/lib/alphagsm}"
+BIN_DIR="${BIN_DIR:-/usr/local/bin}"
+SBIN_DIR="${SBIN_DIR:-/usr/local/sbin}"
+CONFIG_PATH="${CONFIG_PATH:-/etc/alphagsm.conf}"
+SUDOERS_PATH="${SUDOERS_PATH:-/etc/sudoers.d/gameservers}"
+ALPHAGSM_USER="${ALPHAGSM_USER:-alphagsm}"
+ALPHAGSM_HOME="${ALPHAGSM_HOME:-/home/$ALPHAGSM_USER}"
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  echo "This installer must be run as root." >&2
+  exit 1
+fi
+
+if ! id "$ALPHAGSM_USER" >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir "$ALPHAGSM_HOME" --shell /usr/sbin/nologin "$ALPHAGSM_USER"
+fi
+
+mkdir -p "$INSTALL_ROOT" "$BIN_DIR" "$SBIN_DIR" "$ALPHAGSM_HOME/gitlive" "$ALPHAGSM_HOME/downloads"
+
+cp -a "$REPO_ROOT"/. "$INSTALL_ROOT"/
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  cp "$INSTALL_ROOT/alphagsm.conf-template" "$CONFIG_PATH"
+fi
+
+ln -sfn "$INSTALL_ROOT/alphagsm" "$BIN_DIR/alphagsm"
+install -m 0755 "$INSTALL_ROOT/scripts/gitalphagsm" "$SBIN_DIR/gitalphagsm"
+
+cat >"$SUDOERS_PATH" <<EOF
+%alphagsm       ALL = ($ALPHAGSM_USER) NOPASSWD:$INSTALL_ROOT/alphagsm-downloads
+EOF
+chmod 0440 "$SUDOERS_PATH"
+
+chown -R "$ALPHAGSM_USER":"$ALPHAGSM_USER" "$ALPHAGSM_HOME"
+
+cat <<EOF
+AlphaGSM system-wide install complete.
+
+System config:
+  $CONFIG_PATH
+
+Shared download user:
+  $ALPHAGSM_USER
+
+Shared directories:
+  $ALPHAGSM_HOME/gitlive
+  $ALPHAGSM_HOME/downloads
+
+Code install root:
+  $INSTALL_ROOT
+
+Shared command:
+  $BIN_DIR/alphagsm
+
+Root git helper:
+  $SBIN_DIR/gitalphagsm
+
+Sudoers file:
+  $SUDOERS_PATH
+EOF

--- a/system_install_tests/run_system_install_in_container.sh
+++ b/system_install_tests/run_system_install_in_container.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+set -x
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER_IMAGE="${CONTAINER_IMAGE:-ubuntu:24.04}"
+
+docker run --rm \
+  -v "$REPO_ROOT:/src" \
+  "$CONTAINER_IMAGE" \
+  /bin/bash -lc '
+set -Eeuo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y python3 sudo git
+
+mkdir -p /etc/sudoers.d
+
+cd /src
+bash ./scripts/install-system-wide.sh
+
+test -f /etc/alphagsm.conf
+test -d /home/alphagsm
+test -d /home/alphagsm/gitlive
+test -d /home/alphagsm/downloads
+test -d /usr/local/lib/alphagsm
+test -f /usr/local/lib/alphagsm/alphagsm
+test -f /usr/local/lib/alphagsm/alphagsm-downloads
+test -L /usr/local/bin/alphagsm
+test "$(readlink -f /usr/local/bin/alphagsm)" = "/usr/local/lib/alphagsm/alphagsm"
+test -x /usr/local/sbin/gitalphagsm
+test -f /etc/sudoers.d/gameservers
+grep -Fx "%alphagsm       ALL = (alphagsm) NOPASSWD:/usr/local/lib/alphagsm/alphagsm-downloads" /etc/sudoers.d/gameservers
+
+python3 /usr/local/bin/alphagsm --help >/tmp/alphagsm-help.txt
+test -s /tmp/alphagsm-help.txt
+'


### PR DESCRIPTION
## Summary

This PR expands AlphaGSM’s documentation, install tooling, CI coverage, and repo automation guidance.

## What Changed

### Documentation
- rewrote `README.md` to be much easier for non-technical users to follow
- expanded `DEVELOPERS.md` into a much more technical architecture and maintenance guide
- added a proper `docs/` structure for server-specific documentation
- added install documentation for:
  - local user installs
  - system-wide shared installs
- updated docs to use smoke tests as the main real-world examples of working server lifecycle flows

### In-Code Documentation
- added module, class, method, and function docstrings across the parsable production codebase
- improved inline discoverability for core runtime, screen, server, backup, settings, SteamCMD, and game module code

### Install Tooling
- added `scripts/install-local-user.sh`
- added `scripts/install-system-wide.sh`
- added `scripts/gitalphagsm`
- documented the intended system-wide layout:
  - `/etc/alphagsm.conf`
  - `/home/alphagsm/`
  - `/usr/local/lib/alphagsm`
  - `/usr/local/sbin/gitalphagsm`
  - `/usr/local/bin/alphagsm`
  - `/etc/sudoers.d/gameservers`

### CI / Testing
- kept linting and coverage in CI
- added wiki publishing support from tracked repository docs
- added a new container-based `system-install-test` job
- system install test validates the global install layout and sudoers entry inside a fresh container
- smoke and integration tests continue to run per-server in parallel

### Repo Automation Guidance
- added `AGENTS.md`
- added repo-local skills under `skills/`
  - `skills/smoke-driven-docs/`
  - `skills/server-lifecycle/`

## Notes
- the repository docs are now the source of truth, with the wiki published from them
- smoke tests are now treated as canonical examples of real working server lifecycle behaviour
- `downloadermodules/steamcmd.py` remains excluded from maintained lint/doc verification because it is still legacy parser-broken code

## Validation
- `bash ./lint.sh` passes at `10.00/10`
- workflow YAML and shell scripts were syntax-checked
- installer execution itself was not run on the host machine because the system-wide path modifies real root-owned locations
